### PR TITLE
versions_route implemented with for loop

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -440,10 +440,10 @@
         },
         "sqlalchemy-utils": {
             "hashes": [
-                "sha256:7a7fab14bed80df065412bbf71a0a9b0bfeb4b7c111c2d9bffe57283082f3a6b"
+                "sha256:fb66e9956e41340011b70b80f898fde6064ec1817af77199ee21ace71d7d6ab0"
             ],
             "index": "pypi",
-            "version": "==0.36.6"
+            "version": "==0.36.8"
         },
         "urllib3": {
             "hashes": [

--- a/src/api/endpoints.py
+++ b/src/api/endpoints.py
@@ -2,13 +2,15 @@
 Routes and views for the flask application.
 """
 
-import pkg_resources
 import os
-from flask import send_from_directory
 from sys import version_info
-from flask import jsonify
-from flask_swagger import swagger
+
+import pkg_resources
 from api import app
+from flask import jsonify
+from flask import send_from_directory
+from flask_swagger import swagger
+
 
 @app.route('/favicon.ico')
 def favicon():
@@ -28,40 +30,14 @@ def version():
         200:
             description: List of versions of dependencies
     """
-    return jsonify({
-        "python_version": "{}.{}".format(version_info.major, version_info.minor),
-        "pip_version": "{}".format(pkg_resources.get_distribution('pip').version),
-        "flask-dance_version": "{}".format(pkg_resources.get_distribution('flask-dance').version),
-        "oauthlib_version": "{}".format(pkg_resources.get_distribution('oauthlib').version),
-        "requests_version": "{}".format(pkg_resources.get_distribution('requests').version),
-        "certifi_version": "{}".format(pkg_resources.get_distribution('certifi').version),
-        "cherdet_version": "{}".format(pkg_resources.get_distribution('chardet').version),
-        "idna_version": "{}".format(pkg_resources.get_distribution('idna').version),
-        "urllib3_version": "{}".format(pkg_resources.get_distribution('urllib3').version),
-        "urlobject_version": "{}".format(pkg_resources.get_distribution('urlobject').version),
-        "pyopenssl_version": "{}".format(pkg_resources.get_distribution('pyopenssl').version),
-        "flask-sqlalchemy_version": "{}".format(pkg_resources.get_distribution('flask-sqlalchemy').version),
-        "sqlalchemy_version": "{}".format(pkg_resources.get_distribution('sqlalchemy').version),
-        "sqlalchemy-utils_version": "{}".format(pkg_resources.get_distribution('sqlalchemy-utils').version),
-        "flask-swagger_version": "{}".format(pkg_resources.get_distribution('flask-swagger').version),
-        "pyyaml_version": "{}".format(pkg_resources.get_distribution('pyyaml').version),
-        "flask-swagger-ui_version": "{}".format(pkg_resources.get_distribution('flask-swagger-ui').version),
-        "jinja2_version": "{}".format(pkg_resources.get_distribution('jinja2').version),
-        "flask_version": "{}".format(pkg_resources.get_distribution('flask').version),
-        "cffi_version": "{}".format(pkg_resources.get_distribution('cffi').version),
-        "pycparser_version": "{}".format(pkg_resources.get_distribution('pycparser').version),
-        "click_version": "{}".format(pkg_resources.get_distribution('click').version),
-        "cryptography_version": "{}".format(pkg_resources.get_distribution('cryptography').version),
-        "itsdangerous_version": "{}".format(pkg_resources.get_distribution('itsdangerous').version),
-        "jsonify_version": "{}".format(pkg_resources.get_distribution('jsonify').version),
-        "mysql-connector-python_version": "{}".format(pkg_resources.get_distribution('mysql-connector-python').version),
-        "protobuf_version": "{}".format(pkg_resources.get_distribution('protobuf').version),
-        "setuptools_version": "{}".format(pkg_resources.get_distribution('setuptools').version),
-        "markupsafe_version": "{}".format(pkg_resources.get_distribution('markupsafe').version),
-        "pycparser_version": "{}".format(pkg_resources.get_distribution('pycparser').version),
-        "six_version": "{}".format(pkg_resources.get_distribution('six').version),
-        "werkzeug_version": "{}".format(pkg_resources.get_distribution('werkzeug').version)
-    })
+
+    installed_packages = sorted(pkg_resources.working_set, key=lambda x: x.key)
+    jsonDict = {"python_version": "{}.{}".format(version_info.major, version_info.minor)}
+    for i in installed_packages:
+        jsonDict[i.key] = i.version
+
+    return jsonify(jsonDict)
+
 
 @app.route("/spec")
 def spec():


### PR DESCRIPTION
The `piplock` file was updated automatically from the PyCharm IDE. We can keep it or remove it, it doesn't make a difference.